### PR TITLE
Feature/readonly contracts for readonly functions

### DIFF
--- a/src/BaseEvents.js
+++ b/src/BaseEvents.js
@@ -14,7 +14,7 @@ export default class BaseEvents {
       return cache[key];
     }
     cache[key] = subject(toKey(subjectBase, eventName, 'Event'));
-    const contract = await this.target.contract;
+    const contract = await this.target.readonlyContract;
     const trackedEvent = contract.filters[eventName](...(filterArgs || []));
     contract.on(trackedEvent, (...args) => {
       cache[key].next(...args);

--- a/src/core/ElasticDAO.js
+++ b/src/core/ElasticDAO.js
@@ -93,8 +93,8 @@ export default class ElasticDAO extends QueryFilterable {
     this.dao = dao;
   }
 
-  static contract(sdk, address) {
-    return sdk.contract({ abi: ElasticDAOContract.abi, address });
+  static contract(sdk, address, readonly = false) {
+    return sdk.contract({ abi: ElasticDAOContract.abi, address, readonly });
   }
 
   get contract() {
@@ -112,6 +112,10 @@ export default class ElasticDAO extends QueryFilterable {
 
   get id() {
     return this.dao.uuid;
+  }
+
+  get readonlyContract() {
+    return this.constructor.contract(this.sdk, this.dao.uuid, true);
   }
 
   async exit(deltaLambda, overrides = {}) {
@@ -153,7 +157,7 @@ export default class ElasticDAO extends QueryFilterable {
     const pools = [];
     const saneOverrides = sanitizeOverrides(overrides, true);
     let i = 0;
-    let pool = `${await this.contract.liquidityPools(
+    let pool = `${await this.readonlyContract.liquidityPools(
       i,
       saneOverrides,
     )}`.toLowerCase();
@@ -161,7 +165,7 @@ export default class ElasticDAO extends QueryFilterable {
       while (isAddress(pool)) {
         pools.push(pool);
         i += 1;
-        pool = `${await this.contract.liquidityPools(
+        pool = `${await this.readonlyContract.liquidityPools(
           i,
           saneOverrides,
         )}`.toLowerCase();
@@ -210,7 +214,7 @@ export default class ElasticDAO extends QueryFilterable {
   }
 
   async summoners(overrides = {}) {
-    const elasticDAO = await this.contract;
+    const elasticDAO = await this.readonlyContract;
 
     return Promise.all(
       upTo(this.dao.numberOfSummoners).map((i) =>

--- a/src/core/ElasticDAOFactory.js
+++ b/src/core/ElasticDAOFactory.js
@@ -4,8 +4,12 @@ import DAO from '../models/DAO';
 import ElasticDAOFactoryContract from '../../artifacts/ElasticDAOFactory.json';
 
 export default class ElasticDAOFactory extends Base {
-  static contract(sdk, address) {
-    return sdk.contract({ abi: ElasticDAOFactoryContract.abi, address });
+  static contract(sdk, address, readonly = false) {
+    return sdk.contract({
+      abi: ElasticDAOFactoryContract.abi,
+      address,
+      readonly,
+    });
   }
 
   get address() {
@@ -14,6 +18,10 @@ export default class ElasticDAOFactory extends Base {
 
   get contract() {
     return this.constructor.contract(this.sdk, this.address);
+  }
+
+  get readonlyContract() {
+    return this.constructor.contract(this.sdk, this.address, true);
   }
 
   async deployDAOAndToken(
@@ -65,7 +73,7 @@ export default class ElasticDAOFactory extends Base {
   }
 
   async deployedDAOAddresses(overrides = {}) {
-    const factory = await this.contract;
+    const factory = await this.readonlyContract;
     const deployedDAOCount = await factory.deployedDAOCount();
 
     const promises = upTo(deployedDAOCount.toNumber()).map((i) =>

--- a/src/models/ElasticModel.js
+++ b/src/models/ElasticModel.js
@@ -1,9 +1,9 @@
 /* eslint class-methods-use-this: 0 */
 import { isBigNumber } from '@pie-dao/utils';
 import { toKey } from '../utils';
-import Base from '../Base';
+import QueryFilterable from '../QueryFilterable';
 
-export default class ElasticModel extends Base {
+export default class ElasticModel extends QueryFilterable {
   constructor(sdk) {
     super(sdk);
     this._loaded = false;

--- a/src/models/Token.js
+++ b/src/models/Token.js
@@ -96,16 +96,20 @@ export default class Token extends ElasticModel {
 
   // Class functions
 
-  static contract(sdk, address) {
+  static contract(sdk, address, readonly = false) {
     validateIsAddress(address, { prefix });
-    return sdk.contract({ abi: TokenContract.abi, address });
+    return sdk.contract({ abi: TokenContract.abi, address, readonly });
   }
 
   static async deserialize(sdk, uuid, ecosystem, overrides = {}) {
     validateIsAddress(uuid, { prefix });
     validateIsEcosystem(ecosystem);
 
-    const tokenModel = await this.contract(sdk, ecosystem.tokenModelAddress);
+    const tokenModel = await this.contract(
+      sdk,
+      ecosystem.tokenModelAddress,
+      true,
+    );
 
     const {
       eByL,
@@ -147,7 +151,11 @@ export default class Token extends ElasticModel {
     validateIsAddress(daoAddress, { prefix });
 
     const ecosystem = await Ecosystem.deserialize(sdk, daoAddress, overrides);
-    const tokenModel = await this.contract(sdk, ecosystem.tokenModelAddress);
+    const tokenModel = await this.contract(
+      sdk,
+      ecosystem.tokenModelAddress,
+      true,
+    );
 
     return tokenModel.exists(
       uuid,
@@ -209,6 +217,10 @@ export default class Token extends ElasticModel {
 
   get numberOfTokenHolders() {
     return this.toNumber(cache[this.id].numberOfTokenHolders);
+  }
+
+  get readonlyContract() {
+    return this.constructor.contract(this.sdk, this.address);
   }
 
   get symbol() {

--- a/src/models/TokenHolder.js
+++ b/src/models/TokenHolder.js
@@ -79,9 +79,9 @@ export default class TokenHolder extends ElasticModel {
 
   // Class functions
 
-  static contract(sdk, address) {
+  static contract(sdk, address, readonly = false) {
     validateIsAddress(address, { prefix });
-    return sdk.contract({ abi: TokenHolderContract.abi, address });
+    return sdk.contract({ abi: TokenHolderContract.abi, address, readonly });
   }
 
   static async deserialize(sdk, uuid, ecosystem, token, overrides = {}) {
@@ -92,6 +92,7 @@ export default class TokenHolder extends ElasticModel {
     const tokenHolderModel = await this.contract(
       sdk,
       ecosystem.tokenHolderModelAddress,
+      true,
     );
 
     const ecosystemObject = ecosystem.toObject(false);
@@ -125,6 +126,7 @@ export default class TokenHolder extends ElasticModel {
     const tokenHolderModel = await this.contract(
       sdk,
       token.ecosystem.tokenHolderModelAddress,
+      true,
     );
 
     return tokenHolderModel.exists(
@@ -163,6 +165,10 @@ export default class TokenHolder extends ElasticModel {
 
   get lambda() {
     return this.toBigNumber(cache[this.id].lambda, 18);
+  }
+
+  get readonlyContract() {
+    return this.constructor.contract(this.sdk, this.address, true);
   }
 
   get token() {

--- a/src/tokens/ElasticGovernanceToken.js
+++ b/src/tokens/ElasticGovernanceToken.js
@@ -30,8 +30,12 @@ export default class ElasticGovernanceToken extends QueryFilterable {
     this.dao = dao;
   }
 
-  static contract(sdk, address) {
-    return sdk.contract({ abi: ElasticGovernanceTokenContract.abi, address });
+  static contract(sdk, address, readonly = false) {
+    return sdk.contract({
+      abi: ElasticGovernanceTokenContract.abi,
+      address,
+      readonly,
+    });
   }
 
   get address() {
@@ -51,12 +55,16 @@ export default class ElasticGovernanceToken extends QueryFilterable {
     return cache[key];
   }
 
+  get readonlyContract() {
+    return this.constructor.contract(this.sdk, this.address, true);
+  }
+
   async getEcosystem() {
     return this.dao.ecosystem.refresh();
   }
 
   async allowance(ownerAddress, spenderAddress, overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const allowance = await elasticGovernanceToken.allowance(
       ownerAddress,
       spenderAddress,
@@ -76,7 +84,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async balanceOf(accountAddress, overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const balance = await elasticGovernanceToken.balanceOf(
       accountAddress,
       sanitizeOverrides(overrides, true),
@@ -86,7 +94,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async balanceOfInShares(accountAddress, overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const balanceOfInShares = await elasticGovernanceToken.balanceOfInShares(
       accountAddress,
       sanitizeOverrides(overrides, true),
@@ -95,7 +103,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async balanceOfVoting(accountAddress, overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const balanceOfVoting = await elasticGovernanceToken.balanceOfVoting(
       accountAddress,
       sanitizeOverrides(overrides, true),
@@ -135,7 +143,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async decimals() {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const decimals = await elasticGovernanceToken.decimals();
     return decimals;
   }
@@ -145,7 +153,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
     if (!endingBlock) {
       endingBlock = await this.sdk.provider.getBlockNumber();
     }
-    const tokenHolderModelContract = await this.sdk.models.TokenHolder.contract(
+    const tokenHolderModelContract = await this.sdk.models.TokenHolder.readonlyContract(
       this.dao.ecosystem.tokenHolderModelAddress,
     );
     const holders = new Set();
@@ -195,7 +203,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async name(overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const name = await elasticGovernanceToken.name(
       sanitizeOverrides(overrides, true),
     );
@@ -203,7 +211,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async numberOfTokenHolders(overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const number = await elasticGovernanceToken.numberOfTokenHolders(
       sanitizeOverrides(overrides, true),
     );
@@ -212,7 +220,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async symbol(overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const symbol = await elasticGovernanceToken.symbol(
       sanitizeOverrides(overrides, true),
     );
@@ -221,7 +229,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async totalSupply(overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const totalSupply = await elasticGovernanceToken.totalSupply(
       sanitizeOverrides(overrides, true),
     );
@@ -229,7 +237,7 @@ export default class ElasticGovernanceToken extends QueryFilterable {
   }
 
   async totalSupplyInShares(overrides = {}) {
-    const elasticGovernanceToken = await this.contract;
+    const elasticGovernanceToken = await this.readonlyContract;
     const totalSupplyInShares = await elasticGovernanceToken.totalSupplyInShares(
       sanitizeOverrides(overrides, true),
     );


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve. -->

When using blockTags we're relying on archivenode functionality. If a signer has been connected, it's probable that the signer's provider object is not connected to an archive node. This PR adds a `readonly` toggle to the ethersjs contract generation function on the SDK class and reconfigures all non-write function calls to use that toggle.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Linter status: 100% pass
- [X] Changes don't break existing behavior
- [X] Test coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
