### PR TITLE
added standard ERC20 abi when no abi provided

### DIFF
--- a/src/MulticallQueue.js
+++ b/src/MulticallQueue.js
@@ -50,6 +50,7 @@ export default class MulticallQueue {
     }
 
     if (calls.length > 0) {
+      // console.log('Multicall Queue Calls', calls);
       const { data, to } = await this.multicall.populateTransaction.aggregate(
         calls,
       );
@@ -59,6 +60,7 @@ export default class MulticallQueue {
       for (let i = 0; i < decoded.returnData.length; i += 1) {
         const result = this.abiCoder.decode(outputs[i], decoded.returnData[i]);
         callbacks[i](outputs[i].length === 1 ? result[0] : result);
+        // console.log('Multicall Queue Result', result);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -396,7 +396,7 @@ export class SDK extends Subscribable {
       return contract;
     }
 
-    return new MulticallContract(this, contract, abi);
+    return new MulticallContract(this, contract, abi || erc20);
   }
 
   async disconnectSigner() {


### PR DESCRIPTION
- added standard ERC20 abi when no abi provided.

Needs pass multicall:true on SDK to work.

Closes #106 